### PR TITLE
Removed all cyclic dependencies.

### DIFF
--- a/lib/hash/common.js
+++ b/lib/hash/common.js
@@ -1,5 +1,4 @@
-var hash = require('../hash');
-var utils = hash.utils;
+var utils = require('./utils');
 var assert = utils.assert;
 
 function BlockHash() {

--- a/lib/hash/hmac.js
+++ b/lib/hash/hmac.js
@@ -1,7 +1,6 @@
 var hmac = exports;
 
-var hash = require('../hash');
-var utils = hash.utils;
+var utils = require('./utils');
 var assert = utils.assert;
 
 function Hmac(hash, key, enc) {

--- a/lib/hash/ripemd.js
+++ b/lib/hash/ripemd.js
@@ -1,11 +1,10 @@
-var hash = require('../hash');
-var utils = hash.utils;
-
+var utils = require('./utils');
 var rotl32 = utils.rotl32;
 var sum32 = utils.sum32;
 var sum32_3 = utils.sum32_3;
 var sum32_4 = utils.sum32_4;
-var BlockHash = hash.common.BlockHash;
+var common = require('./common');
+var BlockHash = common.BlockHash;
 
 function RIPEMD160() {
   if (!(this instanceof RIPEMD160))

--- a/lib/hash/sha.js
+++ b/lib/hash/sha.js
@@ -1,7 +1,5 @@
-var hash = require('../hash');
-var utils = hash.utils;
+var utils = require('./utils');
 var assert = utils.assert;
-
 var rotr32 = utils.rotr32;
 var rotl32 = utils.rotl32;
 var sum32 = utils.sum32;
@@ -18,7 +16,8 @@ var sum64_4_hi = utils.sum64_4_hi;
 var sum64_4_lo = utils.sum64_4_lo;
 var sum64_5_hi = utils.sum64_5_hi;
 var sum64_5_lo = utils.sum64_5_lo;
-var BlockHash = hash.common.BlockHash;
+var common = require('./common');
+var BlockHash = common.BlockHash;
 
 var sha256_K = [
   0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,


### PR DESCRIPTION
Same story as in indutny/elliptic:
In my attempts to include this code in a React Native project I discovered a number of cyclic dependencies that prevented their default packager from completing. With the liberal rewriting of a few requires all the cycles have been eliminated (according to pahen/madge).

These changes are all superficial. All tests continue to pass.
