### PR TITLE
Make Mocha a dev-dependency again

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
   "homepage": "https://github.com/indutny/hash.js",
   "dependencies": {
     "inherits": "^2.0.3",
-    "minimalistic-assert": "^1.0.0",
-    "mocha": "^3.4.2"
+    "minimalistic-assert": "^1.0.0"
   },
   "devDependencies": {
-    "eslint": "^4.0.0"
+    "eslint": "^4.0.0",
+    "mocha": "^3.4.2"
   }
 }


### PR DESCRIPTION
The change to make it an ordinary dependency must have been an accidental change as part of the dependency bump in https://github.com/indutny/hash.js/commit/423f9b46736f63e63f764a5d4eb165192d9d7f71 – right?