### PR TITLE
fix typescript export

### DIFF
--- a/lib/hash.d.ts
+++ b/lib/hash.d.ts
@@ -1,7 +1,7 @@
 declare var hash: Hash;
 
 declare module "hash.js" {
-    export default hash;
+    export = hash;
 }
 
 interface BlockHash<T> {


### PR DESCRIPTION
for typescript import to work it should be '=' instead of 'default'
```
import * as hash from "hash.js";
```