### PR TITLE
hash: only pad when needed

### DIFF
--- a/lib/hash/common.js
+++ b/lib/hash/common.js
@@ -45,8 +45,10 @@ BlockHash.prototype.update = function update(msg, enc) {
 };
 
 BlockHash.prototype.digest = function digest(enc) {
-  this.update(this._pad());
-  assert(this.pending === null);
+  if (this.pending !== null) {
+    this.update(this._pad());
+    assert(this.pending === null);
+  }
 
   return this._digest(enc);
 };

--- a/test/hash-test.js
+++ b/test/hash-test.js
@@ -121,4 +121,17 @@ describe('Hash', function() {
       ]
     ]);
   });
+
+  it('should return the same digest in subsequent calls', function() {
+    var hashed = hash.sha256().update('abc');
+    assert.equal(
+      hashed.digest('hex'),
+      'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad');
+    assert.equal(
+      hashed.digest('hex'),
+      'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad');
+    assert.equal(
+      hashed.digest('hex'),
+      'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad');
+  });
 });


### PR DESCRIPTION
Only add padding if there are bytes pending. If the padding is
added unconditionally then the hash changes on every `digest()`
call.