### PR TITLE
Fix return type for `MessageDigest#digest` method

### DIFF
--- a/lib/hash.d.ts
+++ b/lib/hash.d.ts
@@ -14,7 +14,7 @@ interface MessageDigest<T> {
     blockSize: number
     outSize: number
     update(msg: any, enc?: 'hex'): T
-    digest(enc?: 'hex'): T
+    digest(enc?: 'hex'): string
 }
 
 interface Hash {

--- a/lib/hash.d.ts
+++ b/lib/hash.d.ts
@@ -14,7 +14,8 @@ interface MessageDigest<T> {
     blockSize: number
     outSize: number
     update(msg: any, enc?: 'hex'): T
-    digest(enc?: 'hex'): string
+    digest(): number[]
+    digest(enc: 'hex'): string
 }
 
 interface Hash {


### PR DESCRIPTION
Fixes https://github.com/indutny/hash.js/issues/17