### PR TITLE
Fix utf8 character handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 sudo: false
 language: node_js
 node_js:
-  - "4"
   - "6"
+  - "8"
+  - "10"
   - "stable"
 branches:
   only:

--- a/lib/hash/utils.js
+++ b/lib/hash/utils.js
@@ -13,14 +13,32 @@ function toArray(msg, enc) {
   var res = [];
   if (typeof msg === 'string') {
     if (!enc) {
+      // Inspired by stringToUtf8ByteArray() in closure-library by Google
+      // https://github.com/google/closure-library/blob/8598d87242af59aac233270742c8984e2b2bdbe0/closure/goog/crypt/crypt.js#L117-L143
+      // Apache License 2.0
+      // https://github.com/google/closure-library/blob/master/LICENSE
+      let p = 0;
       for (var i = 0; i < msg.length; i++) {
         var c = msg.charCodeAt(i);
-        var hi = c >> 8;
-        var lo = c & 0xff;
-        if (hi)
-          res.push(hi, lo);
-        else
-          res.push(lo);
+        if (c < 128) {
+          res[p++] = c;
+        } else if (c < 2048) {
+          res[p++] = (c >> 6) | 192;
+          res[p++] = (c & 63) | 128;
+        } else if (
+          ((c & 0xFC00) == 0xD800) && (i + 1) < msg.length &&
+            ((msg.charCodeAt(i + 1) & 0xFC00) == 0xDC00)) {
+          // Surrogate Pair
+          c = 0x10000 + ((c & 0x03FF) << 10) + (msg.charCodeAt(++i) & 0x03FF);
+          res[p++] = (c >> 18) | 240;
+          res[p++] = ((c >> 12) & 63) | 128;
+          res[p++] = ((c >> 6) & 63) | 128;
+          res[p++] = (c & 63) | 128;
+        } else {
+          res[p++] = (c >> 12) | 224;
+          res[p++] = ((c >> 6) & 63) | 128;
+          res[p++] = (c & 63) | 128;
+        }
       }
     } else if (enc === 'hex') {
       msg = msg.replace(/[^a-z0-9]+/ig, '');

--- a/lib/hash/utils.js
+++ b/lib/hash/utils.js
@@ -5,6 +5,16 @@ var inherits = require('inherits');
 
 exports.inherits = inherits;
 
+function isSurrogatePair(msg, i) {
+  if ((msg.charCodeAt(i) & 0xFC00) !== 0xD800) {
+    return false;
+  }
+  if (i < 0 || i + 1 >= msg.length) {
+    return false;
+  }
+  return (msg.charCodeAt(i + 1) & 0xFC00) === 0xDC00;
+}
+
 function toArray(msg, enc) {
   if (Array.isArray(msg))
     return msg.slice();
@@ -25,10 +35,7 @@ function toArray(msg, enc) {
         } else if (c < 2048) {
           res[p++] = (c >> 6) | 192;
           res[p++] = (c & 63) | 128;
-        } else if (
-          ((c & 0xFC00) == 0xD800) && (i + 1) < msg.length &&
-            ((msg.charCodeAt(i + 1) & 0xFC00) == 0xDC00)) {
-          // Surrogate Pair
+        } else if (isSurrogatePair(msg, i)) {
           c = 0x10000 + ((c & 0x03FF) << 10) + (msg.charCodeAt(++i) & 0x03FF);
           res[p++] = (c >> 18) | 240;
           res[p++] = ((c >> 12) & 63) | 128;

--- a/test/hash-test.js
+++ b/test/hash-test.js
@@ -128,8 +128,8 @@ describe('Hash', function() {
     test(hash[algorithm], [
       'hello', // one byte per character
       'привет', // two bytes per character
-      '您好',  // three bytes per character
-      '👋',  // four bytes per character
+      '您好', // three bytes per character
+      '👋', // four bytes per character
       'hello привет 您好 👋!!!' // mixed character lengths
     ].map(str => [str, crypto
       .createHash(algorithm)

--- a/test/hash-test.js
+++ b/test/hash-test.js
@@ -2,6 +2,7 @@
 /* global describe it */
 
 var assert = require('assert');
+var crypto = require('crypto');
 var hash = require('../');
 
 describe('Hash', function() {
@@ -121,4 +122,19 @@ describe('Hash', function() {
       ]
     ]);
   });
+
+  it('handles utf8 in strings just like crypto', function() {
+    const algorithm = 'sha256';
+    test(hash[algorithm], [
+      'hello', // single byte
+      'привет', // two bytes per character
+      '您好',  // three bytes per character
+      '😀',  // four bytes per character
+      'hello привет 您好 😀'
+    ].map(str => [str, crypto
+      .createHash(algorithm)
+      .update(str)
+      .digest('hex')]));
+  });
+
 });

--- a/test/hash-test.js
+++ b/test/hash-test.js
@@ -126,11 +126,11 @@ describe('Hash', function() {
   it('handles utf8 in strings just like crypto', function() {
     const algorithm = 'sha256';
     test(hash[algorithm], [
-      'hello', // single byte
+      'hello', // one byte per character
       'привет', // two bytes per character
       '您好',  // three bytes per character
-      '😀',  // four bytes per character
-      'hello привет 您好 😀'
+      '👋',  // four bytes per character
+      'hello привет 您好 👋!!!' // mixed character lengths
     ].map(str => [str, crypto
       .createHash(algorithm)
       .update(str)


### PR DESCRIPTION
This PR brings parity between `hash.js` and Node.js `crypto` module, which is crucial for distributed systems. Prior to the fix, utf8 characters were not correctly converted to a byte array and this produced different hash values compared to what `crypto`'s functions did.

Fixes https://github.com/indutny/hash.js/issues/20

I had to remove Node 4 from Travis as it was [failing](https://travis-ci.org/indutny/hash.js/builds/461733657) anyway. This Node version reached its end of life half a year ago, so hope this is fine. Testing for Node 8 and 10 was added.

It'd be great if the patch was released as v2.0.0 as it imposes a breaking change to the hash outputs. We should also describe the changes on the [releases page](https://github.com/indutny/hash.js/releases) to help folks with upgrading.